### PR TITLE
Upgrade Marco from PhD student to PhD candidate

### DIFF
--- a/content/member/marco.md
+++ b/content/member/marco.md
@@ -4,7 +4,7 @@ id = "marco"
 interests = ["Bayesian machine learning", "Information theory", "Signal processing"]
 name = "Marco Cox"
 portrait = "portraits/Marco.jpg"
-short_bio = "PhD student working on probabilistic models and Bayesian machine learning."
+short_bio = "PhD candidate working on probabilistic models and Bayesian machine learning."
 title = "Marco Cox"
 
 [[social]]
@@ -18,14 +18,14 @@ title = "Marco Cox"
     link = "https://github.com/marcocox/"
 
 [[education]]
-    course = "MSc in Electrical Engineering"
+    course = "M.Sc. in Electrical Engineering"
     institution = "TU Eindhoven"
     year = "2014"
 
 [[organizations]]
     name = "TU Eindhoven"
-    role = "PhD student"
+    role = "PhD candidate"
 
 +++
-I'm a PhD student in the field of Bayesian machine learning. My research mainly focusses on probabilistic models and inference algorithms for data-efficient Bayesian optimization. I'm also interested in information theory, signal processing and computer architecture.
+Marco Cox is a PhD candidate in the Electrical Engineering department of [TU Eindhoven](http://www.tue.nl), working in the [BIASlab](http://biaslab.org) team. His research focusses on Bayesian machine learning techniques for optimization and signal processing. He is also interested in information theory, computer architecture, and combinatorics. Marco received the M.Sc. degree in electrical engineering from TU Eindhoven in 2014.
 


### PR DESCRIPTION
- Changed "PhD student" to "PhD candidate";
- Changed "MSc" to "M.Sc." for consistency with others;
- Rewrote the short bio in third person.
