### PR TITLE
Added a script that rebuilds the documentation for FL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,5 @@ preview-website:
 	hugo server -t academic-group -w
 publish:
 	./publish.sh
+rebuild-docs:
+	./rebuild_docs.sh

--- a/rebuild_docs.sh
+++ b/rebuild_docs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Rebuild the documentation
+
+CHECKOUT_FL="/tmp/forneylab"
+
+rm -f -r $CHECKOUT_FL
+git clone git@github.com:biaslab/ForneyLab.jl.git $CHECKOUT_FL
+
+BUILDPATH=$PWD
+rm -f -r $BUILDPATH/static/forneylab/docs/*
+
+julia $CHECKOUT_FL/docs/make.jl
+
+cp -r $CHECKOUT_FL/docs/build/* $BUILDPATH/static/forneylab/docs/
+
+rm -f -r $CHECKOUT_FL
+
+echo "All done."


### PR DESCRIPTION
As a temporary solution I have written a shell script that rebuilds FL documentation and puts it in an appropriate directory in the repo. You can use this script through `make` command: `make rebuild-docs`.  

However, user is still responsible for verifying and commiting the update as well as publishing the updated website. I've decided against autocommits and publishing because of possible errors that can arise during build.