### PR TITLE
Add ReactiveMP software tab

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -163,6 +163,12 @@ tag = "tags"
     weight = 2
 
   [[menu.main]]
+    name = "ReactiveMP.jl"
+    url = "https://biaslab.github.io/ReactiveMP.jl/stable"
+    parent = "software"
+    weight = 2
+
+  [[menu.main]]
     name = "Join us"
     url = "#open-projects"
     weight = 6


### PR DESCRIPTION
This PR adds ReactiveMP.jl link to the documentation to the software tabs panel. 

Do **not** merge until we update `/stable` link of ReactiveMP.jl documentation.