### PR TITLE
Add NeurIPS paper Bart

### DIFF
--- a/content/publication/improved-depth-estimation-of-BNNs.md
+++ b/content/publication/improved-depth-estimation-of-BNNs.md
@@ -11,7 +11,7 @@ selected = false
 title = "Improved Depth Estimation of Bayesian Neural Networks"
 url_code = "https://github.com/biaslab/DepthEstimationBNN"
 url_dataset = ""
-# url_pdf = "https://openreview.net/pdf?id=6TLRVdWGzI"
+url_pdf = "https://openreview.net/pdf?id=6TLRVdWGzI"
 url_project = ""
 url_video = ""
 url_custom = [{name = "OpenReview", url = "https://openreview.net/forum?id=6TLRVdWGzI"}]

--- a/content/publication/improved-depth-estimation-of-BNNs.md
+++ b/content/publication/improved-depth-estimation-of-BNNs.md
@@ -1,0 +1,23 @@
++++
+abstract = "This paper proposes improvements over earlier work by Nazareth and Blei (2022) for estimating the depth of Bayesian neural networks. Here, we propose a discrete truncated normal distribution over the network depth to independently learn its mean and variance. Posterior distributions are inferred by minimizing the variational free energy, which balances the model complexity and accuracy. Our method improves test accuracy in the spiral data set and reduces the variance in posterior depth estimates."
+date = "2024-10-14"
+image = ""
+image_preview = ""
+math = false
+publication = "NeurIPS 2024 Workshop on Bayesian Decision-making and Uncertainty"
+publication_short = "NeurIPS 2024 BDU"
+to_be_published = false
+selected = false
+title = "Improved Depth Estimation of Bayesian Neural Networks"
+url_code = "https://github.com/biaslab/DepthEstimationBNN"
+url_dataset = ""
+# url_pdf = "https://openreview.net/pdf?id=6TLRVdWGzI"
+url_project = ""
+url_video = ""
+url_custom = [{name = "OpenReview", url = "https://openreview.net/forum?id=6TLRVdWGzI"}]
+
+[[authors]]
+    id = "bart"
+[[authors]]
+    id = "bert"
++++

--- a/content/teaching/bmlip.md
+++ b/content/teaching/bmlip.md
@@ -343,7 +343,7 @@ You can access all lecture notes, videos and exercises online through the links 
 
 ### Grading
 
-- The final grade is composed of the results of assignments A1 (10%),  A2 (10%), and a final written exam (80%). The grade will be rounded to the nearest integer. 
+- The final grade is composed of the results of assignments A1 (10%),  A2 (10%), and a final written exam (80%). The grade will be rounded to the nearest integer.
 
 <!---
 See [this Piazza note on how the final grade is computed](https://piazza.com/class/ln1m8n333g5aa/post/6).


### PR DESCRIPTION
Paper does not show up yet because conference date is in the future, not sure whether this is a feature or bug.